### PR TITLE
Add Forever Engine Plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Unsure what to contribute? Check out the `good first issue` [tagged GitHub issue
     - [Edak Engine Docs](https://github.com/Skullbite/Edak-Engine/wiki) - Edak Engine modding documentation.
 - *Forever Engine* - An archived rewrite of the game, originally written by Yoshubs. Includes performance reworks, HScript support, and more.
   - [Forever Engine Feather](https://github.com/Pluma-Team/Forever-Engine-Feather) - A fork of Forever Engine that includes all of its features, a scripting system based on HScript, called SScript, reorganized codebase, an events system based off of Hypno's Lullaby v2 and fully softcoded weeks and characters.
+  - [Forever Engine Plus](https://github.com/Sword352/Forever-Engine-Plus) - A fork of Forever Engine which aims to maintain the engine by adding and optimizing features as well as fixing its bugs. Allow softcoding features for basic objects such as characters, stages, weeks, but also advanced objects such as shaders.
 - [Codename Engine](https://github.com/YoshiCrafter29/CodenameEngine) - A fork of base game that provides full HScript support for advanced softcoding, along with sorted and half rewritten source for optimisation and ease of use.
   - [Codename Engine Docs](https://github.com/YoshiCrafter29/CodenameEngine/wiki) - Codename Engine modding documenation.
 - [Andromeda Engine Legacy](https://github.com/nebulazorua/andromeda-engine-legacy) - Fork of Funkin' with customization and gameplay in mind.


### PR DESCRIPTION
I would like to get my engine, Forever Engine Plus, to get added to the funkin ressouces.
Its a fork of Forever Engine which just maintain the engine, but also fix its bugs, optimize the features and make the modding easier by providing new features such as HScript support, powered by hscript-improved.
https://github.com/Sword352/Forever-Engine-Plus