### PR TITLE
Add Moonchart charting tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Unsure what to contribute? Check out the `good first issue` [tagged GitHub issue
 ## Charting
 
 - [ArrowVortex](https://arrowvortex.ddrnl.com/) - Create or edit stepfiles for various rhythm games, such as [DDR (Dance Dance Revolution)](https://www.ddrgame.com/), [ITG (In The Groove)](<https://en.wikipedia.org/wiki/In_the_Groove_(video_game)>), [PIU (Pump It Up)](https://www.piugame.com/piu.xx/), [StepMania](https://www.stepmania.com/) and [osu!](https://osu.ppy.sh/home)
+- [Moonchart](https://github.com/MaybeMaru/moonchart) - Haxe library able to manage and convert charts made between multiple rhythm games to files usable in many Friday Night Funkin' versions and engines.
 - [fnf-to-sm](https://github.com/Ashen-Haze/fnf-to-sm) - A fork of a [fork](https://github.com/KadeDev/fnf-to-sm) from the original [fnf-to-sm repository](https://github.com/shockdude/fnf-to-sm). Converts Funkin' .json charts to StepMania simfiles and vice versa.
   - Alternatively, using [version 1.7 of Kade Engine](https://github.com/KadeDev/Kade-Engine/releases/tag/1.7) also has a simfile to .json converter.
   - You can also use [SM-to-FNF-Dance-Double](https://github.com/tzheng22/SM-to-FNF-Dance-Double) which has the added benefit of supporting sm file BPM Changes (also designed to work with Psych Engine)


### PR DESCRIPTION
Moonchart is a tool I've been working on for a while to be able to convert many rhythm game chart files.
At the moment it's only a haxelib that gives you access to a bunch of timing backend stuff and converters/parsers for most of the mainline fnf engine formats, vanilla fnf formats and other popular rhytym games like osu!mania and stepmania
An example of the usage can be found [here](https://github.com/MaybeMaru/moonchart?tab=readme-ov-file#how-to-use-moonchart)!