### PR TITLE
Update from Weekend 1 to Playable Pico

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Unsure what to contribute? Check out the `good first issue` [tagged GitHub issue
 
 ## Programming
 
-- [Friday Night Funkin' Official Source Code](https://github.com/FunkinCrew/funkin) - The original open source game by The Funkin' Crew. Last updated for WeekEnd 1.
+- [Friday Night Funkin' Official Source Code](https://github.com/FunkinCrew/funkin) - The original open source game by The Funkin' Crew. Last updated for the Playable Pico update.
 
 ### Engines and Forks
 


### PR DESCRIPTION
I saw an issue requesting to change "Updated for WeekEnd 1" to "Updated for the Playable Pico update," so I thought I'd oblige to propose the change.